### PR TITLE
Fix packagist read error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Various CRC32 implementations",
     "homepage": "https://github.com/google/php-crc32",
     "type": "library",
-    "license": "Apache 2",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "Andrew Brampton",


### PR DESCRIPTION
```
Reading composer.json of google/crc32 (master)
Importing branch master (dev-master)
Skipped branch master, Invalid package information: 
License "Apache 2" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.
```