### PR TITLE
Fix exception namespace

### DIFF
--- a/src/Builtin.php
+++ b/src/Builtin.php
@@ -51,7 +51,7 @@ final class Builtin implements CRCInterface
     public function __construct($polynomial)
     {
         if (!self::supports($polynomial)) {
-            throw new Exception("hash_algos() does not list this polynomial.");
+            throw new \Exception("hash_algos() does not list this polynomial.");
         }
 
         $this->algo = self::$mapping[$polynomial];


### PR DESCRIPTION
I missed this in my last change. Right now instead of getting the expected exception thrown, you get `Fatal Error: Class 'Google\CRC32\Exception' not found`.