### PR TITLE
Fix Builtin::supports() on PHP 5 Windows

### DIFF
--- a/src/Builtin.php
+++ b/src/Builtin.php
@@ -41,7 +41,7 @@ final class Builtin implements CRCInterface
      */
     public static function supports($polynomial)
     {
-        if (!array_key_exists($polynomial, self::$mapping)) {
+        if (!isset(self::$mapping[$polynomial])) {
             return false;
         }
         $algo = self::$mapping[$polynomial];

--- a/tests/BuiltinTest.php
+++ b/tests/BuiltinTest.php
@@ -30,4 +30,21 @@ final class BuiltinTest extends TestCase
 
         new Builtin(CRC32::KOOPMAN);
     }
+
+    /**
+     * @dataProvider supports
+     */
+    public function testSupports($algo, $expected)
+    {
+        $this->assertEquals($expected, Builtin::supports($algo));
+    }
+
+    public function supports()
+    {
+        return [
+            'IEEE' => [CRC32::IEEE, true],
+            'CASTAGNOLI' => [CRC32::CASTAGNOLI, true],
+            'KOOPMAN' => [CRC32::KOOPMAN, false],
+        ];
+    }
 }

--- a/tests/GoogleTest.php
+++ b/tests/GoogleTest.php
@@ -36,4 +36,21 @@ final class GoogleTest extends TestCase
 
         new Google();
     }
+
+    /**
+     * @dataProvider supports
+     */
+    public function testSupports($algo, $expected)
+    {
+        $this->assertEquals($expected, Google::supports($algo));
+    }
+
+    public function supports()
+    {
+        return [
+            'IEEE' => [CRC32::IEEE, false],
+            'CASTAGNOLI' => [CRC32::CASTAGNOLI, true],
+            'KOOPMAN' => [CRC32::KOOPMAN, false],
+        ];
+    }
 }


### PR DESCRIPTION
On Windows PHP 5.x, the following error occurs:

```
array_key_exists(): The first argument should be either a string or an integer
T:\src\github\google-cloud-php\vendor\google\crc32\src\Builtin.php:44
```

This change replaces the `array_key_exists` check with an `isset` check.